### PR TITLE
Supports OpenSearch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.100
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.100
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -24,4 +24,4 @@ jobs:
     - name: Pack
       run: dotnet pack
     - name: Push
-      run: dotnet nuget push src/Elasticsearch.FSharp/bin/Debug/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push src/Elasticsearch.FSharp/bin/Release/*nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/src/Elasticsearch.FSharp/Elasticsearch.FSharp.fsproj
+++ b/src/Elasticsearch.FSharp/Elasticsearch.FSharp.fsproj
@@ -13,8 +13,17 @@
     <PackageTags>fsharp elastic elasticsearch</PackageTags>
     <Description>Compose type-checked ElasticSearch queries with the power of F# language</Description>
     <RepositoryUrl>https://github.com/dbarbashov/Elasticsearch.FSharp</RepositoryUrl>
-    <PackageLicenseUrl>https://github.com/dbarbashov/Elasticsearch.FSharp/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include=".\..\..\LICENSE.md" Pack="true" PackagePath=""/>
+    <None Include=".\..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Utility.fs" />
@@ -54,6 +63,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Elasticsearch.FSharp.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/tests/Elasticsearch.FSharp.Tests/Elasticsearch.FSharp.Tests.fsproj
+++ b/tests/Elasticsearch.FSharp.Tests/Elasticsearch.FSharp.Tests.fsproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <WarningsAsErrors>true</WarningsAsErrors>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsCheck" Version="2.14.0" />
-        <PackageReference Include="FsCheck.NUnit" Version="2.14.0" />
-        <PackageReference Include="nunit" Version="3.11.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+        <PackageReference Include="FsCheck" Version="2.16.6" />
+        <PackageReference Include="FsCheck.NUnit" Version="2.16.6" />
+        <PackageReference Include="nunit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
`flattened` type is Elasticsearch X-Pack. An alternative type `flat_object` was added to OpenSearch 2.7

Limitations: https://opensearch.org/docs/latest/field-types/supported-field-types/flat-object/#limitations

Tracking issue for parameters: https://github.com/opensearch-project/OpenSearch/issues/7137

P.S. I propose to bump the major version to beta